### PR TITLE
feat: Add transformer for links

### DIFF
--- a/src/editor/plugins/autocomplete/transformers/index.ts
+++ b/src/editor/plugins/autocomplete/transformers/index.ts
@@ -4,12 +4,14 @@ import arrows from "./arrows";
 import blockquote from "./blockquote";
 import heading from "./heading";
 import bullet_list from "./bullet_list";
+import link from "./link";
 
 const transformers: { [key: string]: Transformer<any> } = {
   arrows,
   heading,
   blockquote,
   bullet_list,
+  link,
   //
 };
 

--- a/src/editor/plugins/autocomplete/transformers/link.test.ts
+++ b/src/editor/plugins/autocomplete/transformers/link.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import linkTransformer from "./link";
+
+describe("transformer.link", () => {
+  describe("activate", () => {
+    it("activates for valid markdown link", () => {
+      const text = "[Example](https://example.com)";
+      const props = linkTransformer.activate(text);
+      expect(props).toEqual({
+        title: "Example",
+        url: "https://example.com",
+        matchLength: text.length,
+      });
+    });
+
+    it("returns undefined for non-link text", () => {
+      const props = linkTransformer.activate("not a link");
+      expect(props).toBeUndefined();
+    });
+
+    it("only uses first link in string", () => {
+      const props = linkTransformer.activate(
+        "foo [One](https://one.com) bar [Two](https://two.com)",
+      );
+      expect(props?.title).toBe("One");
+      expect(props?.url).toBe("https://one.com");
+    });
+  });
+});

--- a/src/editor/plugins/autocomplete/transformers/link.ts
+++ b/src/editor/plugins/autocomplete/transformers/link.ts
@@ -1,0 +1,51 @@
+import { TextSelection } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+import { schema } from "prosemirror-markdown";
+
+import type { activator, transformer, Transformer } from "../types";
+
+const reLink = /\[([^\]]+)\]\(([^)]+)\)/;
+
+interface Props {
+  title: string;
+  url: string;
+  matchLength: number;
+}
+
+const activate: activator<Props> = (text: string): undefined | Props => {
+  const match = reLink.exec(text);
+  if (match) {
+    return {
+      title: match[1],
+      url: match[2],
+      matchLength: match[0].length,
+    };
+  }
+  return undefined;
+};
+
+const transform: transformer<Props> = (
+  view: EditorView,
+  _: string,
+  { title, url, matchLength }: Props,
+): boolean => {
+  const node = schema.text(title, [schema.marks.link.create({ href: url })]);
+
+  const { $cursor } = view.state.selection as TextSelection;
+  if (!$cursor) return false;
+  view.dispatch(
+    view.state.tr
+      .replaceRangeWith($cursor.pos - matchLength, $cursor.pos, node)
+      .insertText(" ")
+      .scrollIntoView(),
+  );
+
+  return true;
+};
+
+const _transformer: Transformer<Props> = {
+  activate,
+  transform,
+};
+
+export default _transformer;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I've implemented a transformer that lets users insert titled links with the usual `[title](url)` format. I've also added partial tests for the transformer.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

~Currently the PR is a Draft since I'd like to implement a `Mod + K` shortcut too, but that seems difficult right now ([accessing the clipboard is async](https://v2.tauri.app/plugin/clipboard/) while AFAIK commands need to be synchronous). I'll look around for a bit, but if nothing else, at least the transformer is working.~

Edit: No longer a draft!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.